### PR TITLE
Addressモデルを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,3 +8,20 @@
 @import "shared/*";
 @import "posts/*";
 @import "groups/*";
+
+::-webkit-input-placeholder { /* WebKit, Blink, Edge */
+  font-size: 0.9em;
+  letter-spacing: 0.1em;
+  // font-style: italic;
+}
+:-ms-input-placeholder { /* Internet Explorer 10-11 */
+  font-size: 0.9em;
+  letter-spacing: 0.1em;
+  // font-style: italic;
+
+}
+::placeholder{ /* Others */
+  font-size: 0.9em;
+  letter-spacing: 0.1em;
+  // font-style: italic;
+}

--- a/app/assets/stylesheets/groups/show.scss
+++ b/app/assets/stylesheets/groups/show.scss
@@ -1,17 +1,45 @@
-.group-main {
+.group_info {
   margin: 0 auto;
-  max-width: 650px;
+  max-width: 80%;
   &_name {
     text-shadow: rgb(170, 168, 168) 1px 1px 1px;
     font-size: 1.8em;
     font-weight: bold;
     text-align: center;
-    margin-bottom: 50px;
+    margin-bottom: 30px;
   }
   .group_img {
     width: 100%;
     border: solid 2px $light_gray;
-    margin-bottom: 50px;
+  }
+  &_table {
+    margin-top: 20px;
+    background-color: white;
+    width: 100%;
+    border: solid 2px $light_gray;
+    tr {
+      font-size: 0.9em;
+      text-align: center;
+      th {
+        padding: 2px;
+        width: 120px;
+        text-align: center;
+      }
+      th, td {
+        border: solid 1px $light_gray;
+      }
+    }
+  }  &_border {
+    height: 30px;
+    border-top: ridge 1px rgba(102, 83, 0, 0.5);
+    margin: 30px 20px 0;
+  }
+  &_content {
+    background-color: white;
+    padding: 10px 20px;
+    border: solid 2px $light_gray;
+    min-height: 50px;
+    margin-bottom: 15px;
   }
   &_menu {
     background-color: silver;
@@ -42,7 +70,6 @@
     min-height: 300px;
     max-height: 500px;
     width: 300px;
-    // display: none;
     overflow: scroll;
     &_top {
       border-bottom: $menu-border;
@@ -73,10 +100,6 @@
       margin: 15px 0;
     }
   }
-  // .show {
-  //   display: block;
-  // }
-
 }
 .chat-container {
   background-color: white;
@@ -122,7 +145,6 @@
     }
   }
 }
-
 .chat-form {
   background-color: white;
   height: 65px;

--- a/app/assets/stylesheets/modules/list.scss
+++ b/app/assets/stylesheets/modules/list.scss
@@ -11,9 +11,14 @@
     &_left {
       padding: 5px 10px;
       &_image {
+        background-color: gainsboro;
         height: 150px;
         width: 150px;
-        border-radius: 2px;
+        border: solid 2px $light_gray;
+        img {
+          height: 100%;
+          width: 100%;
+        }
       }
     }
     &_right {

--- a/app/assets/stylesheets/posts/show.scss
+++ b/app/assets/stylesheets/posts/show.scss
@@ -17,7 +17,7 @@
     width: 100%;
     border: solid 1px $light_gray;
   }
-  &_block {
+  &_table {
     margin-top: 20px;
     background-color: white;
     width: 100%;

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -47,6 +47,9 @@
     .f_select {
       width: 40%;
     }
+    .f_middle {
+      width: 70%;
+    }
     &_time {
       width: 100%;
       display: flex;

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -69,18 +69,15 @@
       float: right;
       display: flex;
       flex-direction: column;
-      
       .file_column {
         height: 240px;
         margin: 0 auto;
       }
     }
     .js-file_group {
-      // width: 20%;
       height: 50px;
       margin-left: 20px;
       padding-top: 5px;
-      // height: 240px;
     }
     .js-file_group:not(:last-child) {
       height: 240px;
@@ -90,7 +87,6 @@
       border-radius: 2px;  
       width: 100%;
       background-color: white;
-      
     }
     .group_img {
       height: 220px;
@@ -102,7 +98,6 @@
         float: right;
         margin-top: 3px;
         color: $red;
-        // background-color: white;
         font-size: 15px;
       }
     }

--- a/app/assets/stylesheets/users/new.scss
+++ b/app/assets/stylesheets/users/new.scss
@@ -31,7 +31,6 @@
   padding: 30px 50px;
   background-color: $translucent-black;
   width: 700px;
-  overflow: scroll;
   .field {
     &_form {
       width: 300px;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,6 +4,7 @@ class GroupsController < ApplicationController
   def new
     @group = Group.new
     @group.group_pictures.new
+    @group.group_address = GroupAddress.new
   end
 
   def create
@@ -43,7 +44,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:group_name, :content, :prefecture_id, user_ids: [], group_pictures_attributes:[:group_image, :_destroy, :id])
+    params.require(:group).permit(:group_name, :content, user_ids: [], group_pictures_attributes:[:group_image, :_destroy, :id], group_address_attributes:[:prefecture_id, :city, :place,])
   end
 
   def set_group

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -43,7 +43,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:group_name, :content, :prefecture_id, user_ids: [], group_pictures_attributes:[:group_image,  :_destroy, :id])
+    params.require(:group).permit(:group_name, :content, :prefecture_id, user_ids: [], group_pictures_attributes:[:group_image, :_destroy, :id])
   end
 
   def set_group

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,6 +8,7 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    @post.post_address = PostAddress.new
   end
 
   def create
@@ -51,7 +52,7 @@ class PostsController < ApplicationController
 
   private
   def post_params
-    params.require(:post).permit(:title, :event, :detail, :prefecture_id, :accept_id, :event_date, :start_time, :end_time, :post_image, :remove).merge(user_id: current_user.id )
+    params.require(:post).permit(:title, :event, :detail, :accept_id, :event_date, :start_time, :end_time, :post_image, :remove, post_address_attributes:[:prefecture_id, :city, :place]).merge(user_id: current_user.id )
   end
 
   def set_post

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,24 +5,26 @@ class UsersController < ApplicationController
   end
 
   def edit
+    @user = User.find(current_user.id)
+    @user.user_address ||= @user.build_user_address
   end
 
   def update
-    if current_user.update(user_params)
-      if current_user.remove == "1"
-        current_user.update_attribute(:user_image, "")
+    @user = User.find(current_user.id)
+    if @user.update(user_params)
+      if @user.remove == "1"
+        @user.update_attribute(:user_image, "")
       end
       redirect_to root_path
     else
       render :edit
     end
-  end
+  end 
 
 
   private
 
   def user_params
-    params.require(:user).permit(:nickname, :email, :profile, :gender, :age, :prefecture_id, :user_image, :remove)
+    params.require(:user).permit(:nickname, :email, :profile, :gender, :age, :user_image, :remove, user_address_attributes:[:prefecture_id, :city])
   end
-  
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,25 @@
+class Address < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+
+  belongs_to_active_hash :prefecture
+  belongs_to :addressable, polymorphic: true
+
+end
+
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  addressable_type :string(255)
+#  city             :string(255)
+#  place            :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  addressable_id   :bigint
+#  prefecture_id    :integer
+#
+# Indexes
+#
+#  index_addresses_on_addressable_type_and_addressable_id  (addressable_type,addressable_id)
+#

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,15 +1,15 @@
 class Group < ApplicationRecord
-  extend ActiveHash::Associations::ActiveRecordExtensions
 
-  belongs_to_active_hash :prefecture
   has_many :group_users, dependent: :destroy
   has_many :users, through: :group_users
   has_many :group_pictures, dependent: :destroy
   has_many :chats, dependent: :destroy
+  has_one :group_address, as: :addressable, dependent: :destroy
   # belongs_to :category
   accepts_nested_attributes_for :group_pictures, reject_if: proc { |attributes| attributes["group_image"].blank? },allow_destroy: true
+  accepts_nested_attributes_for :group_address
 
-  validates :content, :prefecture_id, :group_name, presence: true
+  validates :content, :group_name, presence: true
   validates :group_name, uniqueness: true, length: { maximum: 20 }
   validates :content, length: { maximum: 500 }
 
@@ -23,12 +23,11 @@ end
 #
 # Table name: groups
 #
-#  id            :bigint           not null, primary key
-#  content       :text(65535)      not null
-#  group_name    :string(255)      not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  prefecture_id :integer          not null
+#  id         :bigint           not null, primary key
+#  content    :text(65535)      not null
+#  group_name :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #

--- a/app/models/group_address.rb
+++ b/app/models/group_address.rb
@@ -1,0 +1,21 @@
+class GroupAddress < Address
+  validates :prefecture_id, presence: { message: "を入力してください" }
+end
+
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  addressable_type :string(255)
+#  city             :string(255)
+#  place            :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  addressable_id   :bigint
+#  prefecture_id    :integer
+#
+# Indexes
+#
+#  index_addresses_on_addressable_type_and_addressable_id  (addressable_type,addressable_id)
+#

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,13 +3,14 @@ class Post < ApplicationRecord
   attr_accessor :remove
 
   belongs_to :user
-  belongs_to_active_hash :prefecture
   belongs_to_active_hash :accept
   has_many :comments, dependent: :destroy
+  has_one :post_address, as: :addressable, dependent: :destroy
+  accepts_nested_attributes_for :post_address
 
   mount_uploader :post_image, ImageUploader
 
-  validates :title, :prefecture_id, :detail, presence: true
+  validates :title, :detail, presence: true
   validates :title, length: { maximum: 40 }
   validates :detail, length: { maximum: 1000 }
   validates :event_date, date: { after_or_equal_to: Proc.new { Date.today } }, allow_blank: true, on: [ :create, :update ] 
@@ -19,18 +20,17 @@ end
 #
 # Table name: posts
 #
-#  id            :bigint           not null, primary key
-#  detail        :text(65535)      not null
-#  end_time      :time
-#  event_date    :date
-#  post_image    :string(255)
-#  start_time    :time
-#  title         :string(255)      not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  accept_id     :integer
-#  prefecture_id :integer          not null
-#  user_id       :bigint
+#  id         :bigint           not null, primary key
+#  detail     :text(65535)      not null
+#  end_time   :time
+#  event_date :date
+#  post_image :string(255)
+#  start_time :time
+#  title      :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  accept_id  :integer
+#  user_id    :bigint
 #
 # Indexes
 #

--- a/app/models/post_address.rb
+++ b/app/models/post_address.rb
@@ -1,0 +1,21 @@
+class PostAddress < Address
+  validates :prefecture_id, presence: { message: "を入力してください" }
+end
+
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  addressable_type :string(255)
+#  city             :string(255)
+#  place            :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  addressable_id   :bigint
+#  prefecture_id    :integer
+#
+# Indexes
+#
+#  index_addresses_on_addressable_type_and_addressable_id  (addressable_type,addressable_id)
+#

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 class User < ApplicationRecord
-  extend ActiveHash::Associations::ActiveRecordExtensions
   attr_accessor :remove
 
   # Include default devise modules. Others available are:
@@ -9,13 +8,14 @@ class User < ApplicationRecord
   
   enum gender: { gender_private: 0, male: 1, female: 2, others: 3 }
   enum age: { age_private: 0, teens: 1, twenties: 2, thirties: 3, forties: 4, fifties: 5, over_sixties: 6 }
-  belongs_to_active_hash :prefecture
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :chats, dependent: :destroy
   has_many :group_users, dependent: :destroy
   has_many :groups, through: :group_users
-
+  has_one :user_address, as: :addressable, dependent: :destroy
+  accepts_nested_attributes_for :user_address
+  
   mount_uploader :user_image, ImageUploader
 
   validates :nickname, :email, presence: true
@@ -42,7 +42,6 @@ end
 #  user_image             :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  prefecture_id          :integer
 #
 # Indexes
 #

--- a/app/models/user_address.rb
+++ b/app/models/user_address.rb
@@ -1,0 +1,21 @@
+class UserAddress < Address
+  validates :place, absence: true
+end
+
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  addressable_type :string(255)
+#  city             :string(255)
+#  place            :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  addressable_id   :bigint
+#  prefecture_id    :integer
+#
+# Indexes
+#
+#  index_addresses_on_addressable_type_and_addressable_id  (addressable_type,addressable_id)
+#

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -42,7 +42,6 @@
                   = f.file_field :group_image, name: "group[group_pictures_attributes][#{@group.group_pictures.count}][group_image]", class: 'js-file hidden'
                   %span.js-remove
                     = icon('fa', 'window-close')
-
             .form-area
               .form-area_label
                 = f.label :content, "グループ紹介"
@@ -51,15 +50,26 @@
               = f.text_area :content, class: "form-area_input f_area"
               - if @group.errors.include?(:content)
                 %p.error-message= @group.errors.full_messages_for(:content).first
-            .form-area
-              .form-area_label
-                = f.label :prefecture_id, "都道府県"
-                .form-area_label_info
-                  必須
-              = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt:"--"}, {class: "form-area_input f_select"}
-              - if @group.errors.include?(:prefecture_id)
-                %p.error-message= @group.errors.full_messages_for(:prefecture_id).first
-            .member-area
+
+            = f.fields_for :group_address do |ff|  
+              .form-area
+                .form-area_label
+                  = ff.label :prefecture_id, "都道府県"
+                  .form-area_label_info
+                    必須
+                = ff.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt:"--"}, {class: "form-area_input f_select"}
+                - if @group.errors.include?(:"group_address.prefecture_id")
+                  %p.error-message= @group.errors.full_messages_for(:"group_address.prefecture_id").first
+
+              .form-area
+                .form-area_label
+                  = ff.label :city, "市区町村"
+                = ff.text_field :city, class: "form-area_input f_field f_select"
+              .form-area
+                .form-area_label
+                  = ff.label :place, "その他場所"
+                = ff.text_field :place, class: "form-area_input f_field f_middle", placeholder: "主な活動場所などがあれば書きましょう"
+
             .btn-area
               = f.submit "登録", class: "actions_btn"
               = link_to "もどる", :back, class: "back_btn"

--- a/app/views/groups/searches/index.html.haml
+++ b/app/views/groups/searches/index.html.haml
@@ -16,7 +16,8 @@
                 .list_right_top_name
                   = group.group_name
                 .list_right_top_right
-                  = group.prefecture.name
+                  = group.group_address.prefecture.name
+                  = group.group_address.city
               .list_right_main
                 = group.content
               .list_right_bottom

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -3,13 +3,30 @@
   .main-container
     .main-wrapper
       .top-container
-        .group-main
-          %h1.group-main_name
+        .group_info
+          %h1.group_info_name
             = @group.group_name
           - if @group.group_pictures.present?
             = image_tag @group.group_pictures.first.group_image.url, alt: "グループ画像", class: "group_img"
 
-          %ul.group-main_menu
+          %table.group_info_table
+            %tr
+              %th
+                活動地域
+              %td
+                = @group.group_address.prefecture.name
+                = @group.group_address.city
+                = @group.group_address.place
+            %tr
+              %th
+                メンバー数
+              %td
+                = @group.users.length
+                人
+          .group_info_border
+          .group_info_content
+            = simple_format(@group.content)
+          %ul.group_info_menu
             %li.cog-btn
               = link_to edit_group_path(@group) do
                 = icon('fas', 'cog')
@@ -17,8 +34,6 @@
               = icon('fas', 'users')
             %li.member-btn
               = icon('fas','plus')
-
-
           .member_modal
             .member_modal_top
               .close-btn
@@ -32,9 +47,7 @@
                   = image_tag "picture/user-2517433_640.png", alt: "ユーザー画像", class: "user_img"
                 .user-data_right
                   .user-data_right_name
-                    = user.nickname
-
-          
+                    = user.nickname          
           .member_modal
             .member_modal_top
               .close-btn
@@ -57,11 +70,8 @@
                       = user.check_box
               .member_modal_bottom
                 = f.submit "追加", class: "login-btn"
-
-
           = link_to "削除する", group_path(@group), method: :delete, class: "actions_btn delete-btn", data: { confirm: "本当に削除しますか？" }
-
-
+          
       .chat-container
         - unless @group.chats.present?
           .chat-container_info
@@ -75,7 +85,6 @@
                 = image_tag "picture/user-2517433_640.png", alt: "ユーザー画像", class: "user_img"
               .chat_user_name
                 = chat.user.nickname
-
             .chat_body
               - if chat.body.present?
                 = simple_format(chat.body, class: "chat_body_bubble") 
@@ -87,8 +96,6 @@
                 - if user_signed_in? && chat.user_id == current_user.id
                   = link_to "削除", group_chat_path(@group, chat.id), method: :delete,
                     data: { confirm: "本当に削除しますか？" }
-      
-      
       = form_with(model: [@group, @chat], class: "chat-form", id: "new_chat", local: true) do |f|
         = f.text_area :body, class: "chat-form_input"
         .chat-form_right

--- a/app/views/posts/_form.html.haml
+++ b/app/views/posts/_form.html.haml
@@ -33,19 +33,28 @@
             - if @post.errors.include?(:detail)
               %p.error-message= @post.errors.full_messages_for(:detail).first
 
-          .form-area
-            .form-area_label
-              = f.label :prefecture_id, "都道府県"
-              .form-area_label_info
-                必須
-            = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt:"--"}, {class: "form-area_input f_select"}
-            - if @post.errors.include?(:prefecture_id)
-              %p.error-message= @post.errors.full_messages_for(:prefecture_id).first
+          = f.fields_for :post_address do |ff|  
+            .form-area
+              .form-area_label
+                = ff.label :prefecture_id, "都道府県"
+                .form-area_label_info
+                  必須
+              = ff.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt:"--"}, {class: "form-area_input f_select"}
+              - if @post.errors.include?(:"post_address.prefecture_id")
+                %p.error-message= @post.errors.full_messages_for(:"post_address.prefecture_id").first
+            .form-area
+              .form-area_label
+                = ff.label :city, "市区町村"
+              = ff.text_field :city, class: "form-area_input f_field f_select"
+            .form-area
+              .form-area_label
+                = ff.label :place, "その他場所"
+              = ff.text_field :place, class: "form-area_input f_field f_middle", placeholder: "具体的な場所があれば書きましょう"
 
           .form-area
             .form-area_label
               = f.label :accept_id, "募集人数"
-            = f.collection_select :accept_id, Accept.all, :id, :name, {prompt:"--"}, {class: "form-area_input f_select"}
+            = f.collection_select :accept_id, Accept.all, :id, :name, {include_blank:"--"}, {class: "form-area_input f_select"}
 
           .form-area
             .form-area_label

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -2,8 +2,8 @@
   = render "share/side-bar"
   .main-container
     .main-wrapper
-      .top-container
-        .top-container_picture
+      -# .top-container
+      -#   .top-container_picture
       .main-wrapper_border
       .list-area
         - @posts.each do |post|
@@ -12,9 +12,7 @@
               .list_left
                 .list_left_image
                   - if post.post_image.present?
-                    = image_tag post.post_image.url, alt: "投稿画像", class: "list_left_image" 
-                    -# 代変画像を用意する
-                  -# - else
+                    = image_tag post.post_image.url, alt: "投稿画像"
               .list_right
                 .list_right_top
                   = post.title
@@ -27,7 +25,9 @@
                 .list_right_second
                   .list_right_second-prace
                     場所:
-                    = post.prefecture.name
+                    = post.post_address.prefecture.name
+                    = post.post_address.city
+                    = post.post_address.place
                   - if post.accept.present?
                     .list_right_second-accept
                       募集人数:

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -8,12 +8,14 @@
             = @post.title
           - if @post.post_image.present?
             = image_tag @post.post_image.url, alt: "投稿画像"
-          %table.post_info_block
+          %table.post_info_table
             %tr
               %th
                 場所
               %td
-                = @post.prefecture.name
+                = @post.post_address.prefecture.name
+                = @post.post_address.city
+                = @post.post_address.place
             %tr
               %th
                 日にち

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,11 +1,11 @@
 .wrapper
   .form-container
-    = form_with model: current_user, local: true do |f|
+    = form_with model: @user, local: true do |f|
       .field
         = f.file_field :user_image, class: "hidden"
-        - if current_user.user_image.present?
+        - if @user.user_image.present?
           %span.pip
-            = image_tag current_user.user_image.url, alt: "投稿画像", class: "user_img" 
+            = image_tag @user.user_image.url, alt: "投稿画像", class: "user_img" 
           = f.label :remove, class: "rm-btn" do
             = icon('fa', 'window-close')
           = f.check_box :remove, class: "hidden"
@@ -14,21 +14,21 @@
       .field
         .field_label
           = f.label :nickname
-        = f.text_field :nickname, class: "field_form", autocomplete: "nickname"
-        - if current_user.errors.include?(:nickname)
-          %p.error-message= current_user.errors.full_messages_for(:nickname).first
+        = f.text_field :nickname, class: "field_form"
+        - if @user.errors.include?(:nickname)
+          %p.error-message= @user.errors.full_messages_for(:nickname).first
       .field
         .field_label
           = f.label :email
-        = f.email_field :email, autofocus: true, class: "field_form", autocomplete: "email"
-        - if current_user.errors.include?(:email)
-          %p.error-message= current_user.errors.full_messages_for(:email).first
+        = f.email_field :email, autofocus: true, class: "field_form"
+        - if @user.errors.include?(:email)
+          %p.error-message= @user.errors.full_messages_for(:email).first
       .field
         .field_label
           = f.label :profile
         = f.text_area :profile, class: "field_form field_profile"
-        - if current_user.errors.include?(:profile)
-          %p.error-message= current_user.errors.full_messages_for(:profile).first
+        - if @user.errors.include?(:profile)
+          %p.error-message= @user.errors.full_messages_for(:profile).first
       .field
         .field_label
           = f.label :gender
@@ -37,9 +37,16 @@
         .field_label
           = f.label :age
         = f.select :age, options_for_select_from_enum(User, :age), {}, {class: "field_form"}
-      .field
-        .field_label
-          = f.label :prefecture
-        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt:"選択してください"}, {class: "field_form"}
+
+        
+      = f.fields_for :user_address do |ff|
+        .field
+          .field_label
+            = ff.label :prefecture_id, "都道府県"
+          = ff.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank:"--"}, {class: "field_form"}
+        .field
+          .field_label
+            = ff.label :city, "市区町村"
+          = ff.text_field :city, class: "field_form"
       .actions
         = f.submit "編集する", class: "actions_btn"

--- a/config/locales/device.ja.yml
+++ b/config/locales/device.ja.yml
@@ -29,8 +29,6 @@ ja:
         profile: プロフィール
         gender: 性別
         age: 年齢
-        prefecture: 都道府県
-
     models:
       user: ユーザ
   devise:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,15 +5,21 @@ ja:
       post:
         title: "タイトル"
         detail: "詳細"
-        prefecture_id: "都道府県"
         event_date: "日にち"
       group:
         group_name: "グループ名"
         content: "グループ紹介"
+      group_address:
         prefecture_id: "都道府県"
+        city: "市区町村"
+        place: "その他場所"
+      post_address:
+        prefecture_id: "都道府県"
+        city: "市区町村"
+        place: "その他場所"
     errors:
       messages:
-        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        record_invalid: "バリデーションに失敗しました: %{errors}"
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
@@ -132,7 +138,7 @@ ja:
       invalid: は不正な値です
       less_than: は%{count}より小さい値にしてください
       less_than_or_equal_to: は%{count}以下の値にしてください
-      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      model_invalid: "バリデーションに失敗しました: %{errors}"
       not_a_number: は数値で入力してください
       not_an_integer: は整数で入力してください
       odd: は奇数にしてください
@@ -180,9 +186,9 @@ ja:
           quadrillion: 千兆
           thousand: 千
           trillion: 兆
-          unit: ''
+          unit: ""
       format:
-        delimiter: ''
+        delimiter: ""
         precision: 3
         significant: true
         strip_insignificant_zeros: true
@@ -198,11 +204,11 @@ ja:
           tb: TB
     percentage:
       format:
-        delimiter: ''
+        delimiter: ""
         format: "%n%"
     precision:
       format:
-        delimiter: ''
+        delimiter: ""
   support:
     array:
       last_word_connector: "、"
@@ -218,12 +224,12 @@ ja:
   enums:
     user:
       gender:
-        gender_private: "非公開"
+        gender_private: "--"
         male: "男性"
         female: "女性"
         others: "他"
       age:
-        age_private: "非公開"
+        age_private: "--"
         teens: "10代"
         twenties: "20代"
         thirties: "30代"

--- a/db/migrate/20200430025620_create_posts.rb
+++ b/db/migrate/20200430025620_create_posts.rb
@@ -3,7 +3,6 @@ class CreatePosts < ActiveRecord::Migration[5.2]
     create_table    :posts do |t|
       t.string      :title,                        null: false
       t.text        :detail,                       null: false
-      t.integer     :prefecture_id,                null: false
       t.integer     :accept_id
       t.date        :event_date,                   default: ""
       t.time        :start_time,                   default: ""

--- a/db/migrate/20200514071545_devise_create_users.rb
+++ b/db/migrate/20200514071545_devise_create_users.rb
@@ -10,7 +10,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string :profile
       t.integer :gender,             default: 0
       t.integer :age,                default: 0
-      t.integer :prefecture_id
       t.string  :user_image
 
 

--- a/db/migrate/20200519022732_create_groups.rb
+++ b/db/migrate/20200519022732_create_groups.rb
@@ -3,7 +3,6 @@ class CreateGroups < ActiveRecord::Migration[5.2]
     create_table :groups do |t|
       t.string :group_name,       null: false
       t.text :content,            null: false
-      t.integer :prefecture_id,   null: false
 
       t.index :group_name, unique: true
 

--- a/db/migrate/20200806060521_create_addresses.rb
+++ b/db/migrate/20200806060521_create_addresses.rb
@@ -1,0 +1,12 @@
+class CreateAddresses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :addresses do |t|
+      t.references :addressable, polymorphic: true
+      t.integer :prefecture_id,  null: false
+      t.string :city,            null: false 
+      t.string :place,           null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200806060521_create_addresses.rb
+++ b/db/migrate/20200806060521_create_addresses.rb
@@ -2,9 +2,9 @@ class CreateAddresses < ActiveRecord::Migration[5.2]
   def change
     create_table :addresses do |t|
       t.references :addressable, polymorphic: true
-      t.integer :prefecture_id,  null: false
-      t.string :city,            null: false 
-      t.string :place,           null: false
+      t.integer :prefecture_id
+      t.string :city
+      t.string :place
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_02_102008) do
+ActiveRecord::Schema.define(version: 2020_08_06_060521) do
+
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "addressable_type"
+    t.bigint "addressable_id"
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "place", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"
+  end
 
   create_table "chats", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "body"
@@ -54,7 +65,6 @@ ActiveRecord::Schema.define(version: 2020_06_02_102008) do
   create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "group_name", null: false
     t.text "content", null: false
-    t.integer "prefecture_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["group_name"], name: "index_groups_on_group_name", unique: true
@@ -63,7 +73,6 @@ ActiveRecord::Schema.define(version: 2020_06_02_102008) do
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
     t.text "detail", null: false
-    t.integer "prefecture_id", null: false
     t.integer "accept_id"
     t.date "event_date"
     t.time "start_time"
@@ -82,7 +91,6 @@ ActiveRecord::Schema.define(version: 2020_06_02_102008) do
     t.string "profile"
     t.integer "gender", default: 0
     t.integer "age", default: 0
-    t.integer "prefecture_id"
     t.string "user_image"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,9 +15,9 @@ ActiveRecord::Schema.define(version: 2020_08_06_060521) do
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "addressable_type"
     t.bigint "addressable_id"
-    t.integer "prefecture_id", null: false
-    t.string "city", null: false
-    t.string "place", null: false
+    t.integer "prefecture_id"
+    t.string "city"
+    t.string "place"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  addressable_type :string(255)
+#  city             :string(255)
+#  place            :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  addressable_id   :bigint
+#  prefecture_id    :integer
+#
+# Indexes
+#
+#  index_addresses_on_addressable_type_and_addressable_id  (addressable_type,addressable_id)
+#
+FactoryBot.define do
+  factory :address do
+    
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  addressable_type :string(255)
+#  city             :string(255)
+#  place            :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  addressable_id   :bigint
+#  prefecture_id    :integer
+#
+# Indexes
+#
+#  index_addresses_on_addressable_type_and_addressable_id  (addressable_type,addressable_id)
+#
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -2,12 +2,11 @@
 #
 # Table name: groups
 #
-#  id            :bigint           not null, primary key
-#  content       :text(65535)      not null
-#  group_name    :string(255)      not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  prefecture_id :integer          not null
+#  id         :bigint           not null, primary key
+#  content    :text(65535)      not null
+#  group_name :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2,18 +2,17 @@
 #
 # Table name: posts
 #
-#  id            :bigint           not null, primary key
-#  detail        :text(65535)      not null
-#  end_time      :time
-#  event_date    :date
-#  post_image    :string(255)
-#  start_time    :time
-#  title         :string(255)      not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  accept_id     :integer
-#  prefecture_id :integer          not null
-#  user_id       :bigint
+#  id         :bigint           not null, primary key
+#  detail     :text(65535)      not null
+#  end_time   :time
+#  event_date :date
+#  post_image :string(255)
+#  start_time :time
+#  title      :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  accept_id  :integer
+#  user_id    :bigint
 #
 # Indexes
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,6 @@
 #  user_image             :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  prefecture_id          :integer
 #
 # Indexes
 #

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -2,12 +2,11 @@
 #
 # Table name: groups
 #
-#  id            :bigint           not null, primary key
-#  content       :text(65535)      not null
-#  group_name    :string(255)      not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  prefecture_id :integer          not null
+#  id         :bigint           not null, primary key
+#  content    :text(65535)      not null
+#  group_name :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -2,18 +2,17 @@
 #
 # Table name: posts
 #
-#  id            :bigint           not null, primary key
-#  date          :date
-#  detail        :text(65535)      not null
-#  end_time      :time
-#  post_image    :string(255)
-#  start_time    :time
-#  title         :string(255)      not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  accept_id     :integer
-#  prefecture_id :integer          not null
-#  user_id       :bigint
+#  id         :bigint           not null, primary key
+#  detail     :text(65535)      not null
+#  end_time   :time
+#  event_date :date
+#  post_image :string(255)
+#  start_time :time
+#  title      :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  accept_id  :integer
+#  user_id    :bigint
 #
 # Indexes
 #

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -8,14 +8,13 @@
 #  encrypted_password     :string(255)      default(""), not null
 #  gender                 :integer          default("gender_private")
 #  nickname               :string(255)      not null
-#  profile                :string(255)      not null
+#  profile                :string(255)
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string(255)
 #  user_image             :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  prefecture_id          :integer
 #
 # Indexes
 #

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -2,12 +2,11 @@
 #
 # Table name: groups
 #
-#  id            :bigint           not null, primary key
-#  content       :text(65535)      not null
-#  group_name    :string(255)      not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  prefecture_id :integer          not null
+#  id         :bigint           not null, primary key
+#  content    :text(65535)      not null
+#  group_name :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -2,18 +2,17 @@
 #
 # Table name: posts
 #
-#  id            :bigint           not null, primary key
-#  detail        :text(65535)      not null
-#  end_time      :time
-#  event_date    :date
-#  post_image    :string(255)
-#  start_time    :time
-#  title         :string(255)      not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  accept_id     :integer
-#  prefecture_id :integer          not null
-#  user_id       :bigint
+#  id         :bigint           not null, primary key
+#  detail     :text(65535)      not null
+#  end_time   :time
+#  event_date :date
+#  post_image :string(255)
+#  start_time :time
+#  title      :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  accept_id  :integer
+#  user_id    :bigint
 #
 # Indexes
 #

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -15,7 +15,6 @@
 #  user_image             :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  prefecture_id          :integer
 #
 # Indexes
 #


### PR DESCRIPTION
## What
ユーザー情報、投稿情報、グループ情報で登録するアドレス用のモデルを用意した。
共通で使用するのでアソシエーションはポリモーフィックで実装してみた。
各モデル毎にバリデーションの内容が少しだけ違うので、Addressモデルに３つ子モデルを作りそのモデルを介して関係を持たせた。

## Why
のちにユーザーがグループや投稿を検索できるようにするため、アドレスの情報を登録できるようにした。